### PR TITLE
Fix ISComm function return values

### DIFF
--- a/docs/user-manual/SDK/CommunicationsArduino.md
+++ b/docs/user-manual/SDK/CommunicationsArduino.md
@@ -94,7 +94,7 @@ void setup()
 
     // Ask for ins_1 message 20 times per second.  Ask for the whole thing, so
     // set 0's for the offset and size
-    messageSize = is_comm_get_data(&comm, DID_INS_1, 0, sizeof(ins_1_t), 1000);
+    messageSize = is_comm_get_data_to_buf(buffer, bufferSize, &comm, DID_INS_1, 0, sizeof(ins_1_t), 1000);
     Serial1.write(comm.rxBuf.start, messageSize); // Transmit the message to the inertialsense device
 }
 ```

--- a/docs/user-manual/SDK/CommunicationsBinary.md
+++ b/docs/user-manual/SDK/CommunicationsBinary.md
@@ -77,7 +77,7 @@ This [IS Communications Example](https://github.com/inertialsense/InertialSenseS
 ```C++
 	// Set INS output Euler rotation in radians to 90 degrees roll for mounting
 	float rotation[3] = { 90.0f*C_DEG2RAD_F, 0.0f, 0.0f };
-	int messageSize = is_comm_set_data(comm, DID_FLASH_CONFIG, sizeof(float) * 3, offsetof(nvm_flash_cfg_t, insRotation), rotation);
+	int messageSize = is_comm_set_data_to_buf(comm, DID_FLASH_CONFIG, sizeof(float) * 3, offsetof(nvm_flash_cfg_t, insRotation), rotation);
 	if (messageSize != serialPortWrite(serialPort, comm->buf.start, messageSize))
 	{
 		printf("Failed to encode and write set INS rotation\r\n");
@@ -88,21 +88,21 @@ This [IS Communications Example](https://github.com/inertialsense/InertialSenseS
 
 ```C++
 	// Ask for INS message w/ update 40ms period (4ms source period x 10).  Set data rate to zero to disable broadcast and pull a single packet.
-	int messageSize = is_comm_get_data(comm, DID_INS_1, 0, 0, 10);
+	int messageSize = is_comm_get_data_to_buf(buffer, bufferSize, comm, DID_INS_1, 0, 0, 10);
 	if (messageSize != serialPortWrite(serialPort, comm->buf.start, messageSize))
 	{
 		printf("Failed to encode and write get INS message\r\n");
 	}
 
 	// Ask for GPS message at period of 200ms (200ms source period x 1).  Offset and size can be left at 0 unless you want to just pull a specific field from a data set.
-	messageSize = is_comm_get_data(comm, DID_GPS1_POS, 0, 0, 1);
+	messageSize = is_comm_get_data_to_buf(buffer, bufferSize, comm, DID_GPS1_POS, 0, 0, 1);
 	if (messageSize != serialPortWrite(serialPort, comm->buf.start, messageSize))
 	{
 		printf("Failed to encode and write get GPS message\r\n");
 	}
 
 	// Ask for IMU message at period of 96ms (DID_FLASH_CONFIG.startupNavDtMs source period x 6).  This could be as high as 1000 times a second (period multiple of 1)
-	messageSize = is_comm_get_data(comm, DID_IMU, 0, 0, 6);
+	messageSize = is_comm_get_data_to_buf(buffer, bufferSize, comm, DID_IMU, 0, 0, 6);
 	if (messageSize != serialPortWrite(serialPort, comm->buf.start, messageSize))
 	{
 		printf("Failed to encode and write get IMU message\r\n");
@@ -118,7 +118,7 @@ This [IS Communications Example](https://github.com/inertialsense/InertialSenseS
 	cfg.command = SYS_CMD_SAVE_PERSISTENT_MESSAGES;
 	cfg.invCommand = ~cfg.command;
 
-	int messageSize = is_comm_set_data(comm, DID_SYS_CMD, 0, 0, &cfg);
+	int messageSize = is_comm_set_data_to_buf(buffer, bufferSize, comm, DID_SYS_CMD, 0, 0, &cfg);
 	if (messageSize != serialPortWrite(serialPort, comm->buf.start, messageSize))
 	{
 		printf("Failed to write save persistent message\r\n");

--- a/docs/user-manual/application-config/time_sync.md
+++ b/docs/user-manual/application-config/time_sync.md
@@ -86,7 +86,7 @@ Example:
 rmc_t rmc;
 rmc.bits = RMC_BITS_STROBE_IN_TIME;
 
-int messageSize = is_comm_set_data(comm, DID_RMC, sizeof(uint64_t), offsetof(rmc_t, bits), &rmc);
+int messageSize = is_comm_set_data_to_buf(buffer, bufferSize, comm, DID_RMC, sizeof(uint64_t), offsetof(rmc_t, bits), &rmc);
 if (messageSize != serialPortWrite(serialPort, comm->buffer, messageSize))
 {
     printf("Failed to write save persistent message\r\n");

--- a/docs/user-manual/com-protocol/isb.md
+++ b/docs/user-manual/com-protocol/isb.md
@@ -22,7 +22,7 @@ The `is_comm_set_data()` function will encode a message used to set data or conf
 void setInsOutputRotation()
 {
     float rotation[3] = { 90.0f*C_DEG2RAD_F, 0.0f, 0.0f };
-    int messageSize = is_comm_set_data(portWrite, 0, comm, DID_FLASH_CONFIG, sizeof(float) * 3, offsetof(nvm_flash_cfg_t, insRotation), rotation);
+    is_comm_set_data(portWrite, 0, comm, DID_FLASH_CONFIG, sizeof(float) * 3, offsetof(nvm_flash_cfg_t, insRotation), rotation);
 }
 ```
 ### Getting Data


### PR DESCRIPTION
Address issue in ISComm where a failure in the serial write can occur and not be reported by is_comm_write(). Now any failure results in return of -1.

is_comm_write() and related functions that writes directly to the serial port should. These should return success or failure because the results are not recoverable as multiple serial port writes occur. Any failure in writing data to the serial port results in return of -1.

is_comm_write_to_buf() and related functions that write into a buffer should return the number of bytes written into the buffer so that the caller can properly send the message.
