### PR TITLE
Clarify how SPI works

### DIFF
--- a/docs/user-manual/com-protocol/SPI.md
+++ b/docs/user-manual/com-protocol/SPI.md
@@ -1,6 +1,6 @@
 # SPI Protocol
 
-The SPI interface provides an alternative method of communications with the IMX-5. The SPI protocol uses much of the same structure and format as the serial communication binary protocol which is outlined in the [Binary Protocol](../com-protocol/SPI.md) section of the users manual.
+The SPI interface provides an alternative method of communications with the IMX-5.  The SPI protocol supports all of the same protocol as the UART and USB interfaces with the exception that it uses a master/slave interface where the IMX is the slave and the master is required to clock data in and out of the IMX.  When no more data is available, zeros are transmitted and the data ready (DRDY) pin goes low indicating the output buffer is empty.
 
 ## Enable SPI
 

--- a/docs/user-manual/com-protocol/SPI.md
+++ b/docs/user-manual/com-protocol/SPI.md
@@ -1,6 +1,6 @@
 # SPI Protocol
 
-The SPI interface provides an alternative method of communications with the IMX-5.  The SPI protocol supports all of the same protocol as the UART and USB interfaces with the exception that it uses a master/slave interface where the IMX is the slave and the master is required to clock data in and out of the IMX.  When no more data is available, zeros are transmitted and the data ready (DRDY) pin goes low indicating the output buffer is empty.
+The SPI interface provides an alternative method of communication with IMX and GPX modules. SPI carries the same [Binary Protocol (`isb`)](isb.md) messages as the UART and USB interfaces, but uses a master/slave interface where the module is the slave and the master is required to clock data in and out of the module. When no more data is available, zeros are transmitted and the data ready (DRDY) pin goes low, indicating the output buffer is empty.
 
 ## Enable SPI
 

--- a/docs/user-manual/hardware/module_imx5.md
+++ b/docs/user-manual/hardware/module_imx5.md
@@ -33,7 +33,7 @@
 | 7    | G7/Tx1/MISO                                   | I/O  | GPIO7<br /> Serial 1 output (TTL)<br /> SPI MISO                       |
 | 8    | G8/CS/STRB                                  | I/O  | GPIO8<br /> SPI CS<br /> Strobe time sync input                       |
 | 9    | G5/SCLK/STRB                                | I/O  | GPIO5<br /> SPI SCLK<br /> Strobe time sync input                     |
-| 10   | G9/nSPI_EN/STRB/DRDY             | I/O  | GPIO9<br />SPI Enable: Hold LOW during boot to enable SPI on G5-G8<br />Strobe time sync input or output. <br />SPI data ready when high alternate pin |
+| 10   | G9/nSPI_EN/STRB/DRDY             | I/O  | GPIO9<br />SPI Enable: Hold LOW during boot to enable SPI on G5-G8<br />Strobe time sync input or output. <br />SPI DRDY alternate pin (active-high: data available when high) |
 | 12   | nRESET                                        |  I   | System reset on logic low. May be left unconnected if not used. |
 | 13   | G14/SWCLK                                | I/O    | GPIO14                                       |
 | 14   | G13/XSDA/PPS2/DRDY                    |   I/O   | GPIO13<br />GNSS2 PPS<br />SPI data available when high<br /> Alt I2C SDA                        |

--- a/docs/user-manual/hardware/module_imx5.md
+++ b/docs/user-manual/hardware/module_imx5.md
@@ -33,7 +33,7 @@
 | 7    | G7/Tx1/MISO                                   | I/O  | GPIO7<br /> Serial 1 output (TTL)<br /> SPI MISO                       |
 | 8    | G8/CS/STRB                                  | I/O  | GPIO8<br /> SPI CS<br /> Strobe time sync input                       |
 | 9    | G5/SCLK/STRB                                | I/O  | GPIO5<br /> SPI SCLK<br /> Strobe time sync input                     |
-| 10   | G9/nSPI_EN/STRB/DRDY             | I/O  | GPIO9<br />SPI Enable: Hold LOW during boot to enable SPI on G5-G8<br />Strobe time sync input or output. <br />SPI data ready alternate pin when high |
+| 10   | G9/nSPI_EN/STRB/DRDY             | I/O  | GPIO9<br />SPI Enable: Hold LOW during boot to enable SPI on G5-G8<br />Strobe time sync input or output. <br />SPI data ready when high alternate pin |
 | 12   | nRESET                                        |  I   | System reset on logic low. May be left unconnected if not used. |
 | 13   | G14/SWCLK                                | I/O    | GPIO14                                       |
 | 14   | G13/XSDA/PPS2/DRDY                    |   I/O   | GPIO13<br />GNSS2 PPS<br />SPI data available when high<br /> Alt I2C SDA                        |

--- a/docs/user-manual/hardware/module_imx5.md
+++ b/docs/user-manual/hardware/module_imx5.md
@@ -33,10 +33,10 @@
 | 7    | G7/Tx1/MISO                                   | I/O  | GPIO7<br /> Serial 1 output (TTL)<br /> SPI MISO                       |
 | 8    | G8/CS/STRB                                  | I/O  | GPIO8<br /> SPI CS<br /> Strobe time sync input                       |
 | 9    | G5/SCLK/STRB                                | I/O  | GPIO5<br /> SPI SCLK<br /> Strobe time sync input                     |
-| 10   | G9/nSPI_EN/STRB/DRDY             | I/O  | GPIO9<br />SPI Enable: Hold LOW during boot to enable SPI on G5-G8<br />Strobe time sync input or output. <br />SPI data ready alternate location |
+| 10   | G9/nSPI_EN/STRB/DRDY             | I/O  | GPIO9<br />SPI Enable: Hold LOW during boot to enable SPI on G5-G8<br />Strobe time sync input or output. <br />SPI data ready alternate pin when high |
 | 12   | nRESET                                        |  I   | System reset on logic low. May be left unconnected if not used. |
 | 13   | G14/SWCLK                                | I/O    | GPIO14                                       |
-| 14   | G13/XSDA/PPS2/DRDY                    |   I/O   | GPIO13<br />GNSS2 PPS<br />SPI Data Ready<br /> Alt I2C SDA                        |
+| 14   | G13/XSDA/PPS2/DRDY                    |   I/O   | GPIO13<br />GNSS2 PPS<br />SPI data available when high<br /> Alt I2C SDA                        |
 | 15   | G12/XSCL/SWO                              | I/O    | GPIO12<br /> Alt I2C SCL                                                  |
 | 16   | G11/SWDIO                                      | I/O    | GPIO11                                                             |
 | 17   | G10/BOOT                         | I/O    | Leave unconnected. BOOT mode used in manufacturing. !!! WARNING !!! Asserting a logic high (+3.3V) will cause the IMX to reboot into ROM bootloader (DFU) mode. |

--- a/docs/user-manual/hardware/module_imx6.md
+++ b/docs/user-manual/hardware/module_imx6.md
@@ -29,10 +29,10 @@
 | 7    | G7/Tx1/MISO                                   | I/O  | GPIO7<br /> Serial 1 output (TTL)<br /> SPI MISO                       |
 | 8    | G8/CS/STRB                                  | I/O  | GPIO8<br /> SPI CS<br /> Strobe time sync input                       |
 | 9    | G5/SCLK/STRB                                | I/O  | GPIO5<br /> SPI SCLK<br /> Strobe time sync input                     |
-| 10   | G9/nSPI_EN/STRB/DRDY             | I/O  | GPIO9<br />SPI Enable: Hold LOW during boot to enable SPI on G5-G8<br />Strobe time sync input or output. <br />SPI data available when high |
+| 10   | G9/nSPI_EN/STRB/DRDY             | I/O  | GPIO9<br />SPI Enable: Hold LOW during boot to enable SPI on G5-G8<br />Strobe time sync input or output. <br />SPI data available alternate pin when high  |
 | 12   | nRESET                                        |  I   | System reset on logic low. May be left unconnected if not used. |
 | 13   | G14/SWCLK                                | I/O    | GPIO14                                       |
-| 14   | G13/XSDA/PPS2/DRDY                    |   I/O   | GPIO13<br />GNSS2 PPS<br />SPI Data Ready<br /> Alt I2C SDA                        |
+| 14   | G13/XSDA/PPS2/DRDY                    |   I/O   | GPIO13<br />GNSS2 PPS<br />SPI Data Ready when high<br /> Alt I2C SDA                        |
 | 15   | G12/XSCL/SWO                              | I/O    | GPIO12<br /> Alt I2C SCL                                                  |
 | 16   | G11/SWDIO                                      | I/O    | GPIO11                                                             |
 | 17   | G10/BOOT                         | I/O    | Leave unconnected. BOOT mode used in manufacturing. !!! WARNING !!! Asserting a logic high (+3.3V) will cause the IMX to reboot into bootloader (DFU) mode. |

--- a/docs/user-manual/hardware/module_imx6.md
+++ b/docs/user-manual/hardware/module_imx6.md
@@ -29,7 +29,7 @@
 | 7    | G7/Tx1/MISO                                   | I/O  | GPIO7<br /> Serial 1 output (TTL)<br /> SPI MISO                       |
 | 8    | G8/CS/STRB                                  | I/O  | GPIO8<br /> SPI CS<br /> Strobe time sync input                       |
 | 9    | G5/SCLK/STRB                                | I/O  | GPIO5<br /> SPI SCLK<br /> Strobe time sync input                     |
-| 10   | G9/nSPI_EN/STRB/DRDY             | I/O  | GPIO9<br />SPI Enable: Hold LOW during boot to enable SPI on G5-G8<br />Strobe time sync input or output. <br />SPI data available alternate pin when high  |
+| 10   | G9/nSPI_EN/STRB/DRDY             | I/O  | GPIO9<br />SPI Enable: Hold LOW during boot to enable SPI on G5-G8<br />Strobe time sync input or output. <br />SPI data available when high alternate pin |
 | 12   | nRESET                                        |  I   | System reset on logic low. May be left unconnected if not used. |
 | 13   | G14/SWCLK                                | I/O    | GPIO14                                       |
 | 14   | G13/XSDA/PPS2/DRDY                    |   I/O   | GPIO13<br />GNSS2 PPS<br />SPI Data Ready when high<br /> Alt I2C SDA                        |

--- a/docs/user-manual/hardware/module_imx6.md
+++ b/docs/user-manual/hardware/module_imx6.md
@@ -32,7 +32,7 @@
 | 10   | G9/nSPI_EN/STRB/DRDY             | I/O  | GPIO9<br />SPI Enable: Hold LOW during boot to enable SPI on G5-G8<br />Strobe time sync input or output. <br />SPI data ready (DRDY) is active-high on this alternate pin; data is available when high  |
 | 12   | nRESET                                        |  I   | System reset on logic low. May be left unconnected if not used. |
 | 13   | G14/SWCLK                                | I/O    | GPIO14                                       |
-| 14   | G13/XSDA/PPS2/DRDY                    |   I/O   | GPIO13<br />GNSS2 PPS<br />SPI Data Ready when high<br /> Alt I2C SDA                        |
+| 14   | G13/XSDA/PPS2/DRDY                    |   I/O   | GPIO13<br />GNSS2 PPS<br />Data Ready (DRDY) is active high<br /> Alt I2C SDA                        |
 | 15   | G12/XSCL/SWO                              | I/O    | GPIO12<br /> Alt I2C SCL                                                  |
 | 16   | G11/SWDIO                                      | I/O    | GPIO11                                                             |
 | 17   | G10/BOOT                         | I/O    | Leave unconnected. BOOT mode used in manufacturing. !!! WARNING !!! Asserting a logic high (+3.3V) will cause the IMX to reboot into bootloader (DFU) mode. |

--- a/docs/user-manual/hardware/module_imx6.md
+++ b/docs/user-manual/hardware/module_imx6.md
@@ -29,7 +29,7 @@
 | 7    | G7/Tx1/MISO                                   | I/O  | GPIO7<br /> Serial 1 output (TTL)<br /> SPI MISO                       |
 | 8    | G8/CS/STRB                                  | I/O  | GPIO8<br /> SPI CS<br /> Strobe time sync input                       |
 | 9    | G5/SCLK/STRB                                | I/O  | GPIO5<br /> SPI SCLK<br /> Strobe time sync input                     |
-| 10   | G9/nSPI_EN/STRB/DRDY             | I/O  | GPIO9<br />SPI Enable: Hold LOW during boot to enable SPI on G5-G8<br />Strobe time sync input or output. <br />SPI data ready |
+| 10   | G9/nSPI_EN/STRB/DRDY             | I/O  | GPIO9<br />SPI Enable: Hold LOW during boot to enable SPI on G5-G8<br />Strobe time sync input or output. <br />SPI data available when high |
 | 12   | nRESET                                        |  I   | System reset on logic low. May be left unconnected if not used. |
 | 13   | G14/SWCLK                                | I/O    | GPIO14                                       |
 | 14   | G13/XSDA/PPS2/DRDY                    |   I/O   | GPIO13<br />GNSS2 PPS<br />SPI Data Ready<br /> Alt I2C SDA                        |

--- a/docs/user-manual/hardware/module_imx6.md
+++ b/docs/user-manual/hardware/module_imx6.md
@@ -29,7 +29,7 @@
 | 7    | G7/Tx1/MISO                                   | I/O  | GPIO7<br /> Serial 1 output (TTL)<br /> SPI MISO                       |
 | 8    | G8/CS/STRB                                  | I/O  | GPIO8<br /> SPI CS<br /> Strobe time sync input                       |
 | 9    | G5/SCLK/STRB                                | I/O  | GPIO5<br /> SPI SCLK<br /> Strobe time sync input                     |
-| 10   | G9/nSPI_EN/STRB/DRDY             | I/O  | GPIO9<br />SPI Enable: Hold LOW during boot to enable SPI on G5-G8<br />Strobe time sync input or output. <br />SPI data available when high alternate pin |
+| 10   | G9/nSPI_EN/STRB/DRDY             | I/O  | GPIO9<br />SPI Enable: Hold LOW during boot to enable SPI on G5-G8<br />Strobe time sync input or output. <br />SPI data ready (DRDY) is active-high on this alternate pin; data is available when high  |
 | 12   | nRESET                                        |  I   | System reset on logic low. May be left unconnected if not used. |
 | 13   | G14/SWCLK                                | I/O    | GPIO14                                       |
 | 14   | G13/XSDA/PPS2/DRDY                    |   I/O   | GPIO13<br />GNSS2 PPS<br />SPI Data Ready when high<br /> Alt I2C SDA                        |


### PR DESCRIPTION
This pull request updates the documentation for the SPI protocol and the IMX-6 hardware module to clarify the SPI interface behavior and correct the description of the DRDY (Data Ready) signal.

**SPI Protocol Documentation Update:**

* Clarified that the SPI protocol supports the same features as UART and USB, except that it operates as a master/slave interface with the IMX as the slave. Also described the behavior of the DRDY pin, which goes low when the output buffer is empty.

**Hardware Pin Description Correction:**

* Updated the description of pin 10 (`G9/nSPI_EN/STRB/DRDY`) to state that the SPI data is available when the DRDY pin is high, correcting the previous wording.