### PR TITLE
Note internal pull-up/pull-down resistor on IMX-6 QDEC pins

### DIFF
--- a/docs/user-manual/hardware/module_imx6.md
+++ b/docs/user-manual/hardware/module_imx6.md
@@ -40,11 +40,11 @@
 | 19   | G3/Tx0                                        | I/O  | GPIO3<br /> Serial 0 output (TTL)                                 |
 | 20   | G15/PPS1                              | I   | Input for GNSS PPS for time synchronization pulse. |
 | 22   | VCC                                           | I   | 3.3V supply input                                |
-| 28 | QDEC0.A | I | Ground vehicle wheel sensor 0 quadrature channel A input. |
-| 29 | QDEC0.B | I | Ground vehicle wheel sensor 0 quadrature channel B input. |
+| 28 | QDEC0.A | I | Ground vehicle wheel sensor 0 quadrature channel A input. Has an internal pull-up/pull-down resistor and can be left floating if not used. |
+| 29 | QDEC0.B | I | Ground vehicle wheel sensor 0 quadrature channel B input. Has an internal pull-up/pull-down resistor and can be left floating if not used. |
 | 30 | VUSB | I | 3.0V to 3.6V required for USB operation.  Can be left floating if USB is not needed. |
-| 31 | QDEC1.A | I | Ground vehicle wheel sensor 1 quadrature channel A input. |
-| 32 | QDEC1.B | I | Ground vehicle wheel sensor 1 quadrature channel B input. |
+| 31 | QDEC1.A | I | Ground vehicle wheel sensor 1 quadrature channel A input. Has an internal pull-up/pull-down resistor and can be left floating if not used. |
+| 32 | QDEC1.B | I | Ground vehicle wheel sensor 1 quadrature channel B input. Has an internal pull-up/pull-down resistor and can be left floating if not used. |
 
 <sup>\*</sup>External transceiver required for CAN interface.
 


### PR DESCRIPTION
## Summary
- Adds a note to pins 28, 29, 31, and 32 (QDEC0.A, QDEC0.B, QDEC1.A, QDEC1.B) on the IMX-6 pinout table: they have an internal pull-up/pull-down resistor and can be left floating if the wheel quadrature encoder inputs are not used.
- Matches the existing note style already used for VUSB (pin 30) and nRESET (pin 12) in the same table.

Jira: SN-8312

## Test plan
- [ ] Confirm the rendered pinout table on the built docs site shows the updated descriptions correctly for pins 28, 29, 31, and 32.