### PR TITLE
Extend external aiding with speed, heading, attitude, and IMU inputs (SN-8318)

### DIFF
--- a/docs/user-manual/imx/external-aiding.md
+++ b/docs/user-manual/imx/external-aiding.md
@@ -194,7 +194,7 @@ cltool -c /dev/ttyUSB0 -set "{DID_EXT_AIDING_VEL: {status: 1, timeOfWeekMs: <tow
 
 cltool -c /dev/ttyUSB0 -set "{DID_EXT_AIDING_SPEED: {status: 1, timeOfWeekMs: <tow>, speed: <s>, offset: [0,0,0], var: 0.25}}"
 
-cltool -c /dev/ttyUSB0 -set "{DID_EXT_AIDING_DIR_SPEED: {timeOfWeekMs: <tow>, speed: <s>, offset: [0,0,0], direction: [1,0,0], var: 0.25}}"
+cltool -c /dev/ttyUSB0 -set "{DID_EXT_AIDING_DIR_SPEED: {status: 0, timeOfWeekMs: <tow>, speed: <s>, offset: [0,0,0], direction: [1,0,0], var: 0.25}}"
 
 cltool -c /dev/ttyUSB0 -set "{DID_EXT_AIDING_HEADING: {status: 1, timeOfWeekMs: <tow>, heading: <rad>, var: 0.01}}"
 

--- a/docs/user-manual/imx/external-aiding.md
+++ b/docs/user-manual/imx/external-aiding.md
@@ -14,7 +14,7 @@ Seven data sets are available:
 | `DID_EXT_AIDING_DIR_SPEED`    | `ext_aiding_dir_speed_t`   | Directional speed (e.g. airspeed)     | Yes |
 | `DID_EXT_AIDING_HEADING`      | `ext_aiding_heading_t`     | Heading (true, magnetic, or course)   | Yes |
 | `DID_EXT_AIDING_ATTITUDE`     | `ext_aiding_attitude_t`    | Full attitude (euler or quaternion)   | Yes |
-| `DID_EXT_AIDING_IMU`          | `ext_aiding_imu_t`         | Gyro/accel                            | No — see [below](#did_ext_aiding_imu) |
+| `DID_EXT_IMU`                 | `imu_t`                    | Gyro/accel                            | No — see [below](#did_ext_imu) |
 
 All seven are independent — supply whichever ones match the sensors you have. Each carries its own GPS time of week and a discard-on-invalid observation variance (or, for attitude, a full covariance matrix).
 
@@ -154,25 +154,32 @@ typedef struct PACKED
 } ext_aiding_attitude_t;
 ```
 
-## DID_EXT_AIDING_IMU
+## DID_EXT_IMU
 
-`DID_EXT_AIDING_IMU` carries a raw gyro/accel sample from an external IMU. Unlike the other six types, **it is not currently fused by the EKF** — the DID exists so an external IMU can be streamed to and logged by the IMX (e.g. for offline analysis or a future consistency-check/blended time-update path), but it has no effect on the navigation solution today.
+`DID_EXT_IMU` carries a raw gyro/accel sample from an external IMU. It reuses the SDK's existing `imu_t` — the same struct as `DID_IMU`/`DID_IMU_RAW`/`DID_REFERENCE_IMU` — rather than a bespoke type. Unlike the other six types, **it is not currently fused by the EKF** — the DID exists so an external IMU can be streamed to and logged by the IMX (e.g. for offline analysis or a future consistency-check/blended time-update path), but it has no effect on the navigation solution today.
 
 ```c
-/** (DID_EXT_AIDING_IMU) External IMU (gyro/accel) input. Not currently fused by the INS/EKF. */
+/** (DID_IMU, DID_IMU_RAW, DID_REFERENCE_IMU, DID_EXT_IMU) Single combined Inertial Measurement
+ *  Unit (IMU) sample, in body/sensor frame. */
 typedef struct PACKED
 {
-    uint32_t   timeOfWeekMs; // GPS time of week (since Sunday morning) in milliseconds
-    uint32_t   status;       // reserved, set to 0
-    float      pqr[3];       // angular rate, IMU/body frame {p,q,r} (rad/s)
-    float      acc[3];       // linear acceleration, IMU/body frame {x,y,z} (m/s^2)
-    float      pqrVar[3];    // gyro noise variance, per axis ((rad/s)^2)
-    float      accVar[3];    // accelerometer noise variance, per axis ((m/s^2)^2)
-} ext_aiding_imu_t;
+    double      time;    // Time since boot up in seconds. Convert to GPS time of week by adding gps.towOffset
+    uint32_t    status;  // IMU status flags (eImuStatus)
+    imui_t      I;       // Combined IMU sample: angular rate and acceleration
+} imu_t;
+
+/** Single IMU sample: angular rate and acceleration, in the sensor/body frame. */
+typedef struct PACKED
+{
+    float       pqr[3];  // Gyroscope P, Q, R (angular rate about body X, Y, Z) in radians/second
+    float       acc[3];  // Acceleration X, Y, Z in meters/second^2, in body frame
+} imui_t;
 ```
 
+Because `DID_EXT_IMU` reuses `imu_t` as-is, its `time` field is seconds since boot (matching `DID_IMU`'s convention), not the GPS time-of-week-in-milliseconds convention the other six external aiding types use — convert using the same `gps.towOffset` relationship other IMU DIDs use if you need GPS time.
+
 !!! note
-    `DID_EXT_AIDING_IMU` also has no relay/logging RMC bit (unlike the six fused types below), so it can't be relayed to another port for logging the way the others can — poll or stream it directly from the port it's written to.
+    `DID_EXT_IMU` also has no relay/logging RMC bit (unlike the six fused types below), so it can't be relayed to another port for logging the way the others can — poll or stream it directly from the port it's written to.
 
 ## Sending Data to the IMX
 
@@ -207,10 +214,10 @@ Whatever external aiding observations the IMX receives — from a host or from a
 | `RMC_BITS_EXT_AIDING_HEADING`    | `DID_EXT_AIDING_HEADING` |
 | `RMC_BITS_EXT_AIDING_ATTITUDE`   | `DID_EXT_AIDING_ATTITUDE` |
 
-`DID_EXT_AIDING_IMU` has no RMC bit and is not relayed (see [above](#did_ext_aiding_imu)). All six bits above are included in the IMX PPD presets by default. All seven DIDs appear in the EvalTool's **Data Sets** and **Logger** tabs.
+`DID_EXT_IMU` has no RMC bit and is not relayed (see [above](#did_ext_imu)). All six bits above are included in the IMX PPD presets by default. All seven DIDs appear in the EvalTool's **Data Sets** and **Logger** tabs.
 
 !!! note
-    Enabling these bits on the IMX only controls whether received observations are relayed back out for logging — it has no effect on whether the EKF consumes them. The EKF always fuses whatever valid external aiding data it receives on any port (except `DID_EXT_AIDING_IMU`, which it doesn't consume at all today).
+    Enabling these bits on the IMX only controls whether received observations are relayed back out for logging — it has no effect on whether the EKF consumes them. The EKF always fuses whatever valid external aiding data it receives on any port (except `DID_EXT_IMU`, which it doesn't consume at all today).
 
 ## Using a GPX-1 as an External Aiding Source
 
@@ -238,7 +245,7 @@ Behavior:
 - (IMX/SDK) SN-8317, SN-8318 — `DID_EXT_AIDING_POS`/`DID_EXT_AIDING_VEL` added.
 - (GPX-1) SN-8472 — GPX-1 restates its GNSS1 solution as external aiding observations.
 - (IMX/EvalTool) SN-8317 — external aiding relay/logging support.
-- (IMX/SDK) SN-8318 — `DID_EXT_AIDING_SPEED`/`DID_EXT_AIDING_DIR_SPEED`/`DID_EXT_AIDING_HEADING`/`DID_EXT_AIDING_ATTITUDE`/`DID_EXT_AIDING_IMU` added.
+- (IMX/SDK) SN-8318 — `DID_EXT_AIDING_SPEED`/`DID_EXT_AIDING_DIR_SPEED`/`DID_EXT_AIDING_HEADING`/`DID_EXT_AIDING_ATTITUDE`/`DID_EXT_IMU` added.
 
 <a href="https://inertialsense.com/"><center>
 

--- a/docs/user-manual/imx/external-aiding.md
+++ b/docs/user-manual/imx/external-aiding.md
@@ -2,21 +2,26 @@
 
 ## Overview
 
-External aiding lets a host computer or an external sensor feed position and velocity observations directly into the IMX EKF, independent of any GNSS receiver. This is useful when the platform has a position/velocity source the IMX cannot otherwise see — for example a second INS, a vision or SLAM system, an alternate GNSS receiver, or an RTK correction service running on the host.
+External aiding lets a host computer or an external sensor feed observations directly into the IMX EKF, independent of any GNSS receiver. This is useful when the platform has a sensor the IMX cannot otherwise see — for example a second INS, a vision or SLAM system, an alternate GNSS receiver, an airspeed/pitot sensor, a compass, or an RTK correction service running on the host.
 
-Two data sets are used:
+Seven data sets are available:
 
-| DID                  | Struct              | Observation |
-| -------------------- | -------------------- | ----------- |
-| `DID_EXT_AIDING_POS`  | `ext_aiding_pos_t`   | Position    |
-| `DID_EXT_AIDING_VEL`  | `ext_aiding_vel_t`   | Velocity    |
+| DID                          | Struct                    | Observation                          | Fused by the EKF |
+| ----------------------------- | -------------------------- | ------------------------------------- | :---------------: |
+| `DID_EXT_AIDING_POS`          | `ext_aiding_pos_t`         | Position                              | Yes |
+| `DID_EXT_AIDING_VEL`          | `ext_aiding_vel_t`         | Velocity                              | Yes |
+| `DID_EXT_AIDING_SPEED`        | `ext_aiding_speed_t`       | Scalar speed (3D or horizontal)       | Yes |
+| `DID_EXT_AIDING_DIR_SPEED`    | `ext_aiding_dir_speed_t`   | Directional speed (e.g. airspeed)     | Yes |
+| `DID_EXT_AIDING_HEADING`      | `ext_aiding_heading_t`     | Heading (true, magnetic, or course)   | Yes |
+| `DID_EXT_AIDING_ATTITUDE`     | `ext_aiding_attitude_t`    | Full attitude (euler or quaternion)   | Yes |
+| `DID_EXT_AIDING_IMU`          | `ext_aiding_imu_t`         | Gyro/accel                            | No — see [below](#did_ext_aiding_imu) |
 
-Both are independent — you may supply position only, velocity only, or both. Each carries its own GPS time of week, the frame the measurement was taken in, the offset of the point of measurement from the IMU origin, and a per-axis observation variance.
+All seven are independent — supply whichever ones match the sensors you have. Each carries its own GPS time of week and a discard-on-invalid observation variance (or, for attitude, a full covariance matrix).
 
 !!! important
-    A zero variance on any axis causes the entire observation to be discarded by the EKF. `var` must always reflect a realistic (non-zero) uncertainty of the measurement — do not use zero to mean "perfect" or "unknown."
+    A non-positive variance (or, for `DID_EXT_AIDING_ATTITUDE`, a non-positive covariance diagonal) causes the entire observation to be discarded by the EKF. Variance must always reflect a realistic (non-zero) uncertainty of the measurement — do not use zero to mean "perfect" or "unknown."
 
-## Data Structures
+## Position and Velocity
 
 ```c
 /** Frame of measurement for an external aiding observation, held in the low nibble of
@@ -57,9 +62,121 @@ typedef struct PACKED
 - **`offset`** — the lever arm from the IMU origin to the point of measurement (e.g. the antenna phase center of an external GNSS receiver), expressed in the IMU/body frame. Set to `[0,0,0]` if the source measures at the IMU origin.
 - **`var`** — per-axis observation variance in NED. This is what the EKF weights the observation by, and what its outlier (NIS) gate checks the innovation against — report your source's actual uncertainty rather than an optimistic value.
 
+## Speed
+
+`DID_EXT_AIDING_SPEED` carries a scalar speed with no direction — for example a wheel-speed sensor or a GNSS-derived ground speed that doesn't expose a velocity vector.
+
+```c
+enum eExtAidingSpeedType
+{
+    EXT_AIDING_SPEED_TYPE_MASK       = 0x0000000F,
+    EXT_AIDING_SPEED_TYPE_3D         = 1,  // full 3D velocity magnitude, |v|
+    EXT_AIDING_SPEED_TYPE_HORIZONTAL = 2   // horizontal (ground) velocity magnitude only, |v_NE|
+};
+
+/** (DID_EXT_AIDING_SPEED) External aiding scalar speed observation. */
+typedef struct PACKED
+{
+    uint32_t   timeOfWeekMs; // GPS time of week (since Sunday morning) in milliseconds
+    uint32_t   status;       // Speed type, 1=3D magnitude, 2=horizontal magnitude (see eExtAidingSpeedType)
+    float      speed;        // speed (m/s)
+    float      var;          // observation variance (m^2/s^2). Must be non-zero or the observation is discarded.
+    float      offset[3];    // point of measurement relative to IMU origin in IMU/body frame {x,y,z} (m)
+} ext_aiding_speed_t;
+```
+
+## Directional Speed (Airspeed)
+
+`DID_EXT_AIDING_DIR_SPEED` carries a speed measured along a fixed direction in the IMU/body frame — the natural fit for an airspeed/pitot sensor, which measures flow along the direction it's pointed (typically the body X axis).
+
+```c
+/** (DID_EXT_AIDING_DIR_SPEED) External aiding directional speed observation. `direction` is a
+ *  unit vector in the IMU/body frame (e.g. [1,0,0] for a forward-pointing airspeed sensor);
+ *  `speed` is the velocity component along that direction at the point of measurement. */
+typedef struct PACKED
+{
+    uint32_t   timeOfWeekMs; // GPS time of week (since Sunday morning) in milliseconds
+    uint32_t   status;       // reserved, set to 0
+    float      speed;        // speed along `direction` (m/s)
+    float      var;          // observation variance (m^2/s^2). Must be non-zero or the observation is discarded.
+    float      offset[3];    // point of measurement relative to IMU origin in IMU/body frame {x,y,z} (m)
+    float      direction[3]; // unit vector, in IMU/body frame, along which `speed` is measured
+} ext_aiding_dir_speed_t;
+```
+
+## Heading
+
+`DID_EXT_AIDING_HEADING` carries a single heading angle, in one of three senses:
+
+```c
+enum eExtAidingHeadingType
+{
+    EXT_AIDING_HEADING_TYPE_MASK     = 0x0000000F,
+    EXT_AIDING_HEADING_TYPE_TRUE     = 1, // true heading (body X axis bearing relative to true north)
+    EXT_AIDING_HEADING_TYPE_MAGNETIC = 2, // magnetic heading (converted to true using the EKF's declination estimate)
+    EXT_AIDING_HEADING_TYPE_COURSE   = 3  // course over ground (direction of travel — not necessarily the same as body heading)
+};
+
+/** (DID_EXT_AIDING_HEADING) External aiding heading observation. */
+typedef struct PACKED
+{
+    uint32_t   timeOfWeekMs; // GPS time of week (since Sunday morning) in milliseconds
+    uint32_t   status;       // Heading type, 1=true, 2=magnetic, 3=course over ground (see eExtAidingHeadingType)
+    float      heading;      // heading (rad), 0 = north, positive clockwise, range [-pi, pi]
+    float      var;          // observation variance (rad^2). Must be non-zero or the observation is discarded.
+} ext_aiding_heading_t;
+```
+
+!!! note
+    `TRUE`/`MAGNETIC` heading are treated as an attitude observation (the bearing the vehicle is physically pointed). `COURSE` (over ground) is treated as a velocity-direction observation instead — the direction the vehicle is actually moving, which can differ from body heading under sideslip, wind, or current. Don't use `COURSE` in place of `TRUE`/`MAGNETIC` if what you actually have is a compass.
+
+## Attitude
+
+`DID_EXT_AIDING_ATTITUDE` carries a full 3-axis attitude, from a source such as a second INS, with a full 3x3 attitude-error covariance rather than a per-axis variance.
+
+```c
+enum eExtAidingAttitudeType
+{
+    EXT_AIDING_ATTITUDE_TYPE_MASK       = 0x0000000F,
+    EXT_AIDING_ATTITUDE_TYPE_EULER      = 1, // att = {roll, pitch, yaw} (rad); att[3] unused
+    EXT_AIDING_ATTITUDE_TYPE_QUATERNION = 2  // att = {w, x, y, z}
+};
+
+/** (DID_EXT_AIDING_ATTITUDE) External aiding attitude observation. `var` is the 3x3
+ *  attitude-error covariance (row-major), expressed as a small-angle roll/pitch/yaw rotation
+ *  vector regardless of whether `att` is euler or quaternion. */
+typedef struct PACKED
+{
+    uint32_t   timeOfWeekMs; // GPS time of week (since Sunday morning) in milliseconds
+    uint32_t   status;       // Attitude representation, 1=euler, 2=quaternion (see eExtAidingAttitudeType)
+    float      att[4];       // attitude, interpreted per `status`: euler {roll,pitch,yaw,-} or quaternion {w,x,y,z}
+    float      var[9];       // 3x3 row-major attitude-error covariance (rad^2). Must have a non-zero diagonal or the observation is discarded.
+} ext_aiding_attitude_t;
+```
+
+## DID_EXT_AIDING_IMU
+
+`DID_EXT_AIDING_IMU` carries a raw gyro/accel sample from an external IMU. Unlike the other six types, **it is not currently fused by the EKF** — the DID exists so an external IMU can be streamed to and logged by the IMX (e.g. for offline analysis or a future consistency-check/blended time-update path), but it has no effect on the navigation solution today.
+
+```c
+/** (DID_EXT_AIDING_IMU) External IMU (gyro/accel) input. Not currently fused by the INS/EKF. */
+typedef struct PACKED
+{
+    uint32_t   timeOfWeekMs; // GPS time of week (since Sunday morning) in milliseconds
+    uint32_t   status;       // reserved, set to 0
+    float      pqr[3];       // angular rate, IMU/body frame {p,q,r} (rad/s)
+    float      acc[3];       // linear acceleration, IMU/body frame {x,y,z} (m/s^2)
+    float      pqrVar[3];    // gyro noise variance, per axis ((rad/s)^2)
+    float      accVar[3];    // accelerometer noise variance, per axis ((m/s^2)^2)
+} ext_aiding_imu_t;
+```
+
+!!! note
+    `DID_EXT_AIDING_IMU` also has no relay/logging RMC bit (unlike the six fused types below), so it can't be relayed to another port for logging the way the others can — poll or stream it directly from the port it's written to.
+
 ## Sending Data to the IMX
 
-`DID_EXT_AIDING_POS` and `DID_EXT_AIDING_VEL` are writable. A host streams an observation to the IMX using the SDK's [Set Data](../com-protocol/isb.md#setting-data) method on any connected port, the same as any other writable DID. Each write is consumed on arrival — there is no need to hold a channel open or stream continuously; send an observation whenever a new one is available from your source.
+All seven DIDs are writable. A host streams an observation to the IMX using the SDK's [Set Data](../com-protocol/isb.md#setting-data) method on any connected port, the same as any other writable DID. Each write is consumed on arrival — there is no need to hold a channel open or stream continuously; send an observation whenever a new one is available from your source.
 
 For bring-up or quick testing, an observation can be injected directly with the CLTool:
 
@@ -67,21 +184,33 @@ For bring-up or quick testing, an observation can be injected directly with the 
 cltool -c /dev/ttyUSB0 -set "{DID_EXT_AIDING_POS: {status: 1, timeOfWeekMs: <tow>, pos: [<x>, <y>, <z>], offset: [0,0,0], var: [4.0, 4.0, 9.0]}}"
 
 cltool -c /dev/ttyUSB0 -set "{DID_EXT_AIDING_VEL: {status: 1, timeOfWeekMs: <tow>, vel: [<vx>, <vy>, <vz>], offset: [0,0,0], var: [0.25, 0.25, 0.25]}}"
+
+cltool -c /dev/ttyUSB0 -set "{DID_EXT_AIDING_SPEED: {status: 1, timeOfWeekMs: <tow>, speed: <s>, offset: [0,0,0], var: 0.25}}"
+
+cltool -c /dev/ttyUSB0 -set "{DID_EXT_AIDING_DIR_SPEED: {timeOfWeekMs: <tow>, speed: <s>, offset: [0,0,0], direction: [1,0,0], var: 0.25}}"
+
+cltool -c /dev/ttyUSB0 -set "{DID_EXT_AIDING_HEADING: {status: 1, timeOfWeekMs: <tow>, heading: <rad>, var: 0.01}}"
+
+cltool -c /dev/ttyUSB0 -set "{DID_EXT_AIDING_ATTITUDE: {status: 1, timeOfWeekMs: <tow>, att: [<roll>,<pitch>,<yaw>,0], var: [0.01,0,0, 0,0.01,0, 0,0,0.01]}}"
 ```
 
 ## Logging Received Observations
 
 Whatever external aiding observations the IMX receives — from a host or from a GPX-1 (see below) — are relayed unmodified to any other port that has the corresponding RMC bit enabled, so the aiding data supplied to the IMX can be logged or inspected on a host PC:
 
-| RMC Bit                     | Relays          |
-| ---------------------------- | ---------------- |
-| `RMC_BITS_EXT_AIDING_POS`    | `DID_EXT_AIDING_POS` |
-| `RMC_BITS_EXT_AIDING_VEL`    | `DID_EXT_AIDING_VEL` |
+| RMC Bit                        | Relays          |
+| -------------------------------- | ---------------- |
+| `RMC_BITS_EXT_AIDING_POS`        | `DID_EXT_AIDING_POS` |
+| `RMC_BITS_EXT_AIDING_VEL`        | `DID_EXT_AIDING_VEL` |
+| `RMC_BITS_EXT_AIDING_SPEED`      | `DID_EXT_AIDING_SPEED` |
+| `RMC_BITS_EXT_AIDING_DIR_SPEED`  | `DID_EXT_AIDING_DIR_SPEED` |
+| `RMC_BITS_EXT_AIDING_HEADING`    | `DID_EXT_AIDING_HEADING` |
+| `RMC_BITS_EXT_AIDING_ATTITUDE`   | `DID_EXT_AIDING_ATTITUDE` |
 
-Both bits are included in the IMX PPD presets by default. `DID_EXT_AIDING_POS` and `DID_EXT_AIDING_VEL` also appear in the EvalTool's **Data Sets** and **Logger** tabs.
+`DID_EXT_AIDING_IMU` has no RMC bit and is not relayed (see [above](#did_ext_aiding_imu)). All six bits above are included in the IMX PPD presets by default. All seven DIDs appear in the EvalTool's **Data Sets** and **Logger** tabs.
 
 !!! note
-    Enabling these bits on the IMX only controls whether received observations are relayed back out for logging — it has no effect on whether the EKF consumes them. The EKF always fuses whatever valid `DID_EXT_AIDING_POS`/`DID_EXT_AIDING_VEL` data it receives on any port.
+    Enabling these bits on the IMX only controls whether received observations are relayed back out for logging — it has no effect on whether the EKF consumes them. The EKF always fuses whatever valid external aiding data it receives on any port (except `DID_EXT_AIDING_IMU`, which it doesn't consume at all today).
 
 ## Using a GPX-1 as an External Aiding Source
 
@@ -109,6 +238,7 @@ Behavior:
 - (IMX/SDK) SN-8317, SN-8318 — `DID_EXT_AIDING_POS`/`DID_EXT_AIDING_VEL` added.
 - (GPX-1) SN-8472 — GPX-1 restates its GNSS1 solution as external aiding observations.
 - (IMX/EvalTool) SN-8317 — external aiding relay/logging support.
+- (IMX/SDK) SN-8318 — `DID_EXT_AIDING_SPEED`/`DID_EXT_AIDING_DIR_SPEED`/`DID_EXT_AIDING_HEADING`/`DID_EXT_AIDING_ATTITUDE`/`DID_EXT_AIDING_IMU` added.
 
 <a href="https://inertialsense.com/"><center>
 

--- a/docs/user-manual/imx/external-aiding.md
+++ b/docs/user-manual/imx/external-aiding.md
@@ -80,7 +80,7 @@ typedef struct PACKED
     uint32_t   timeOfWeekMs; // GPS time of week (since Sunday morning) in milliseconds
     uint32_t   status;       // Speed type, 1=3D magnitude, 2=horizontal magnitude (see eExtAidingSpeedType)
     float      speed;        // speed (m/s)
-    float      var;          // observation variance (m^2/s^2). Must be non-zero or the observation is discarded.
+    float      var;          // observation variance (m^2/s^2). Must be positive or the observation is discarded.
     float      offset[3];    // point of measurement relative to IMU origin in IMU/body frame {x,y,z} (m)
 } ext_aiding_speed_t;
 ```


### PR DESCRIPTION
## Extend external aiding with speed, heading, attitude, and IMU inputs (SN-8318)

### Summary

Builds on the existing `DID_EXT_AIDING_POS`/`DID_EXT_AIDING_VEL` external aiding feature (SN-8317/SN-8318) by adding five more writable observation types, so a host or external sensor can feed the IMX EKF from a wider range of source hardware — wheel-speed sensors, airspeed/pitot tubes, compasses, GPS course, a second INS, or a redundant IMU.

| DID | Observation | Fused by EKF |
|---|---|:---:|
| `DID_EXT_AIDING_SPEED` | Scalar speed (3D or horizontal magnitude) | Yes |
| `DID_EXT_AIDING_DIR_SPEED` | Directional speed, e.g. airspeed (body-frame direction) | Yes |
| `DID_EXT_AIDING_HEADING` | Heading — true, magnetic, or course-over-ground | Yes |
| `DID_EXT_AIDING_ATTITUDE` | Full attitude, euler or quaternion, 3x3 covariance | Yes |
| `DID_EXT_IMU` | Gyro/accel | No — plumbed through and loggable only |

### Design notes

- Each new EKF measurement update (`ExtSpeedUpdate`, `ExtDirSpeedUpdate`, `ExtHeadingUpdate`, `ExtAttitudeUpdate` in `external_ref.cpp`) is built by reusing the exact Jacobian construction already proven in the shipped `ExtPosUpdate`/`ExtVelUpdate`/`MagUpdate`/`GnssCompassUpdate`, rather than a new derivation from scratch — speed/directional-speed project the existing velocity/attitude Jacobian blocks onto a unit direction; heading (true/magnetic) reuses the `-Rb2t·cross_mat(bodyVector)` recipe through an atan2 gradient; attitude uses a direct identity Jacobian on the error states via a quaternion residual.
- **Course-over-ground is deliberately modeled as a velocity-direction observation, not an attitude observation** — it has no attitude-state coupling, since course and heading can differ under sideslip/crab.
- `DID_EXT_AIDING_IMU` has no RMC relay bit — the four bits below `RMC_BITS_EVENT` were the last ones free before the reserved top nibble; flagged in `data_sets.h` for whoever revisits fusion for it.
- Adds a `NavINL_base`/`NavINL2` virtual dispatch layer for the 4 new `Set*Data` calls (mirroring the existing `SetExtPosData`/`SetExtVelData` pattern) — required since `g_nav` is accessed through the abstract base class.

### Scope / what's NOT here

- `DID_EXT_AIDING_IMU` fusion (consistency-check or blended time-update) is out of scope for this PR — plumbing only.
- GPX-1 does not produce any of the 5 new types (unlike POS/VEL) — no GRMC-side changes.

### Test plan

- [x] `NavPostProcess` (`navpp`) builds clean against the shared `nav-common` EKF code (same files used by IMX firmware)
- [ ] IMX-5 / GPX-1 embedded builds (no ARM toolchain available in this environment — needs a real build)
- [ ] Bench test each new DID via `cltool -set` against a live IMX, confirm EKF innovation/NIS behaves sanely (recommend SIL/HIL review of the new Jacobians before flight — novel code, not literal copies)
- [ ] Confirm EvalTool Data Sets/Logger tabs show the 5 new DIDs
- [ ] Confirm relay (`RMC_BITS_EXT_AIDING_*`) logs correctly on a second port

### Related

- SDK: `607ef2e96`, `8b85fefe9` (this branch)
- Docs: `docs/user-manual/imx/external-aiding.md` updated with structs, usage, and `cltool` examples for all 5 new types
- Builds on SN-8317/PR-1266, PR-1653
